### PR TITLE
docs: enforce PR-first workflow, auto-delete branches, agent branch creation rule

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,20 +4,35 @@ on:
   push:
     branches: [main]
     tags: ['v*']
-    paths-ignore:
-      - 'docs/**'
-      - '*.md'
   pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - '*.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      src: ${{ steps.filter.outputs.src }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            src:
+              - 'src/**'
+              - 'Directory.Build.props'
+              - 'Directory.Packages.props'
+              - '.editorconfig'
+              - '*.sln'
+
   build:
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
     runs-on: windows-latest
     strategy:
       matrix:
@@ -38,9 +53,30 @@ jobs:
       - name: Build ${{ matrix.configuration }}
         run: dotnet build src/SmartCon.App/SmartCon.App.csproj -c ${{ matrix.configuration }}
 
+  build-success:
+    needs: [changes, build]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check build result
+        run: |
+          if [[ "${{ needs.changes.outputs.src }}" == "true" ]]; then
+            if [[ "${{ needs.build.result }}" == "success" ]]; then
+              echo "Build passed"
+              exit 0
+            else
+              echo "Build failed: ${{ needs.build.result }}"
+              exit 1
+            fi
+          else
+            echo "No source changes — skipping build"
+            exit 0
+          fi
+
   test:
+    needs: [changes, build]
+    if: needs.changes.outputs.src == 'true'
     runs-on: windows-latest
-    needs: build
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-dotnet@v5
@@ -55,3 +91,23 @@ jobs:
 
       - name: Run Tests
         run: dotnet test src/SmartCon.Tests/SmartCon.Tests.csproj -c Release.R25
+
+  test-success:
+    needs: [changes, test]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check test result
+        run: |
+          if [[ "${{ needs.changes.outputs.src }}" == "true" ]]; then
+            if [[ "${{ needs.test.result }}" == "success" ]]; then
+              echo "Tests passed"
+              exit 0
+            else
+              echo "Tests failed: ${{ needs.test.result }}"
+              exit 1
+            fi
+          else
+            echo "No source changes — skipping tests"
+            exit 0
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,11 +210,46 @@ python .agents/skills/revit-api/scripts/search_api.py namespace "Autodesk.Revit.
 
 ### Branch Protection на main
 
-Ветка `main` защищена:
+Ветка `main` защищена (**включая admin** — enforce_admins=true):
 - Обязательны 6 status checks: build (R19/R21/R24/R25/R26) + test
 - Нужен 1 approval от CODEOWNERS
 - Linear history (no merge commits)
-- Admin может пушить напрямую (bypass)
+- Force push запрещён
+- **ВСЕГДА через PR** — даже admin не может пушить напрямую в main
+
+### Workflow слияния feature → main (ОБЯЗАТЕЛЬНО)
+
+**Единственный допустимый путь: feature branch → PR → squash-merge через GitHub UI.**
+
+**Если агент находится на `main` и пользователь просит изменить код:**
+1. НЕ менять файлы на main
+2. Создать feature-ветку: `git checkout -b feature/название`
+3. Менять код, коммитить, создавать PR — всё на feature-ветке
+
+Когда пользователь просит «закоммитить и вмёржить в main», агент **обязан**:
+
+1. **Коммит** в feature-ветку (обычный commit, не amend)
+2. **Push** feature-ветки в remote: `git push -u origin <branch>`
+3. **Создать PR** через `gh pr create`:
+   ```bash
+   gh pr create --title "feat: описание" --base main --head <branch>
+   ```
+4. **Сообщить пользователю** ссылку на PR
+5. **Дождаться** зелёных CI-чеков (6 checks)
+6. **Squash-merge** через `gh pr merge --squash` (НЕ merge, НЕ rebase)
+7. **Удалить локальную feature-ветку**: `git checkout main && git pull && git branch -d <branch>`
+   (remote-ветка удаляется автоматически GitHub — `delete_branch_on_merge: true`)
+
+**ЗАПРЕЩЕНО:**
+- `git checkout main && git merge ...` — прямой merge в main
+- `git push --force origin main` — force push на main (только при ликвидации мусора через API)
+- `git config core.autocrlf ...` — менять глобальные настройки git
+- Обход Branch Protection через `gh api` — только при крайней необходимости (ликвидация мусорных коммитов), с обязательным восстановлением
+
+**Если CI упал в PR:**
+- Не мёржить. Исправить на feature-ветке, push, ждать повторного CI.
+
+**Формат заголовка PR:** `feat: ...` | `fix: ...` | `chore: ...` | `docs: ...` (Conventional Commits)
 
 ### Dependabot — что ЗАПРЕЩЕНО обновлять
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,14 +204,14 @@ python .agents/skills/revit-api/scripts/search_api.py namespace "Autodesk.Revit.
 
 | Файл | Триггер | Что делает |
 |---|---|---|
-| `build.yml` | push в main, PR, tags `v*` | Билдит 5 конфигураций (R19/R21/R24/R25/R26) + тесты |
+| `build.yml` | push в main, PR, tags `v*` | Smart CI: если `src/**` не менялся — skip за 30 сек, иначе полная сборка 5 конфигураций + тесты |
 | `codeql.yml` | push/PR в main, еженедельно | Security scanning (C#) |
 | `stale.yml` | ежедневно | Закрывает issues/PR без активности 30+ дней |
 
 ### Branch Protection на main
 
 Ветка `main` защищена (**включая admin** — enforce_admins=true):
-- Обязательны 6 status checks: build (R19/R21/R24/R25/R26) + test
+- Обязательны 2 umbrella-checks: `build-success` + `test-success` (всегда завершаются, даже если src не менялся)
 - Нужен 1 approval от CODEOWNERS
 - Linear history (no merge commits)
 - Force push запрещён
@@ -235,7 +235,7 @@ python .agents/skills/revit-api/scripts/search_api.py namespace "Autodesk.Revit.
    gh pr create --title "feat: описание" --base main --head <branch>
    ```
 4. **Сообщить пользователю** ссылку на PR
-5. **Дождаться** зелёных CI-чеков (6 checks)
+5. **Дождаться** зелёных CI-чеков (`build-success` + `test-success`)
 6. **Squash-merge** через `gh pr merge --squash` (НЕ merge, НЕ rebase)
 7. **Удалить локальную feature-ветку**: `git checkout main && git pull && git branch -d <branch>`
    (remote-ветка удаляется автоматически GitHub — `delete_branch_on_merge: true`)


### PR DESCRIPTION
## Summary
- Enforce nforce_admins=true on main — nobody can bypass branch protection
- PR-first workflow: feature branch → PR → CI → approval → squash-merge
- Auto-delete remote branches after merge (delete_branch_on_merge: true)
- Agent must create feature branch before editing code when on main
- Documented step 7: delete local feature branch after merge