### PR TITLE
docs: clarify branch protection — owner bypass, external contributors need review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,9 +210,9 @@ python .agents/skills/revit-api/scripts/search_api.py namespace "Autodesk.Revit.
 
 ### Branch Protection на main
 
-Ветка `main` защищена (**включая admin** — enforce_admins=true):
+Ветка `main` защищена:
 - Обязательны 2 umbrella-checks: `build-success` + `test-success` (всегда завершаются, даже если src не менялся)
-- Нужен 1 approval от CODEOWNERS
+- Нужен 1 approval от CODEOWNERS (внешние контрибьюторы — только через review; владелец может bypass)
 - Linear history (no merge commits)
 - Force push запрещён
 - **ВСЕГДА через PR** — даже admin не может пушить напрямую в main


### PR DESCRIPTION
## Summary
- Fix AGENTS.md: nforce_admins=false (owner can bypass review for own PRs)
- Keep equired_approving_review_count=1 (external contributors must get approval)
- This is the standard pattern for open source projects with a single maintainer