### PR TITLE
chore: freeze SQLite packages in dependabot to prevent breaking net48 builds

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,10 @@ updates:
         versions: [">= 7.0.0"]
       - dependency-name: "PolySharp"
         versions: [">= 2.0.0"]
+      - dependency-name: "Microsoft.Data.Sqlite"
+        versions: [">= 9.0.0"]
+      - dependency-name: "SQLitePCLRaw.bundle_e_sqlite3"
+        versions: [">= 3.0.0"]
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## Summary

Dependabot created two problematic PRs (#25, #26) caught by CI:

- **PR #25** -- Microsoft.Data.Sqlite 10.0.7 (.NET 10 preview). CI passed by chance, but net48 stability not guaranteed. **Closed.**
- **PR #26** -- SQLitePCLRaw.bundle_e_sqlite3 3.0.2 (breaking: new SourceGear.sqlite3 drops AnyCPU support). CI failed on R19/R21/R24. **Closed.**

## Changes

Added ignore rules in dependabot.yml:

| Package | Frozen at | Ignore |
|---|---|---|
| Microsoft.Data.Sqlite | 8.x | >= 9.0.0 |
| SQLitePCLRaw.bundle_e_sqlite3 | 2.x | >= 3.0.0 |

## Why

Both packages are critical for SmartCon.FamilyManager (SQLite catalog). The project supports net48 (Revit 2019-2024), and major versions break compatibility:
- Microsoft.Data.Sqlite 9.0+ may drop net48 (similar to other Microsoft.Extensions packages)
- SQLitePCLRaw 3.0+ requires explicit Platform target (x64/x86), no AnyCPU support