### PR TITLE
chore: bump Microsoft.Data.Sqlite from 8.0.19 to 8.0.26

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -28,7 +28,7 @@
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
 
     <!-- SQLite — version frozen at 8.x (9.0+ may break net48). Compatible with net8.0-windows and net48 (.NET Standard 2.0) -->
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="8.0.19" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="8.0.26" />
     <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.11" />
 
     <!--


### PR DESCRIPTION
Manual application of #29 after merge conflict with #30 (both changed Directory.Packages.props).

Patch update within frozen 8.x line. Previously validated by CI on PR #29 (all 5 configs + tests green).